### PR TITLE
Add Doppelganger cross-domain audio retrieval

### DIFF
--- a/mseb/datasets/doppelganger.py
+++ b/mseb/datasets/doppelganger.py
@@ -1,0 +1,155 @@
+# Copyright 2026 The MSEB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Doppelganger synthetic-real sound-pair dataset."""
+
+import os
+from typing import Any, Mapping
+
+from etils import epath
+from huggingface_hub import hf_hub_download
+from mseb import types
+from mseb import utils
+from mseb.datasets import base
+import pandas as pd
+
+
+_REPO_ID = 'elliottash/doppelganger'
+_REVISION = 'mseb-v1'
+_METADATA_PATH = 'mseb/test.csv'
+
+
+class DoppelgangerDataset(base.MsebDataset):
+  """The fixed 3,065-pair MSEB test configuration of Doppelganger."""
+
+  def __init__(
+      self,
+      split: str = 'test',
+      base_path: str | None = None,
+      repo_id: str = _REPO_ID,
+      revision: str = _REVISION,
+  ):
+    if split != 'test':
+      raise ValueError(f'Split must be test, but got {split}.')
+
+    super().__init__(base_path=base_path, split=split)
+    self.repo_id = repo_id
+    self.revision = revision
+    self._data = self._load_metadata()
+
+  @property
+  def metadata(self) -> types.DatasetMetadata:
+    return types.DatasetMetadata(
+        name='Doppelganger',
+        description=(
+            'Doppelganger pairs real sound effects with audio-conditioned '
+            'synthetic twins across 34 UCS event categories.'
+        ),
+        homepage='https://huggingface.co/datasets/elliottash/doppelganger',
+        version='mseb-v1',
+        license=(
+            'Mixed: clip-level Creative Commons licenses for real audio and '
+            'the Stability AI Community License for synthetic audio'
+        ),
+        mseb_tasks=['retrieval'],
+        citation="""
+@article{ash2026doppelganger,
+  author = {Elliott Ash},
+  title = {Doppelganger: Sound Effects and Their Synthetic Twins},
+  journal = {arXiv preprint arXiv:2607.04337},
+  year = {2026}
+}
+""",
+    )
+
+  def __len__(self) -> int:
+    return len(self._data)
+
+  def _load_metadata(self) -> pd.DataFrame:
+    local_metadata_path = None
+    if self.base_path is not None:
+      local_metadata_path = os.path.join(self.base_path, _METADATA_PATH)
+
+    if local_metadata_path and epath.Path(local_metadata_path).exists():
+      metadata_path = local_metadata_path
+    else:
+      metadata_path = (
+          f'https://huggingface.co/datasets/{self.repo_id}/resolve/'
+          f'{self.revision}/{_METADATA_PATH}'
+      )
+
+    data = pd.read_csv(
+        metadata_path,
+        dtype={'pair_id': str, 'source_clip_id': str},
+    )
+    if data['pair_id'].duplicated().any():
+      raise ValueError('Doppelganger metadata contains duplicate pair IDs.')
+    return data
+
+  def get_task_data(
+      self, task_name: str | None = None, dtype: Mapping[str, Any] | None = None
+  ) -> pd.DataFrame:
+    del task_name
+    return self._data.astype(dtype) if dtype else self._data
+
+  @staticmethod
+  def sound_id(pair_id: str | int, domain: str) -> str:
+    if domain not in ('real', 'synthetic'):
+      raise ValueError(f'Unknown Doppelganger audio domain: {domain}.')
+    return f'{domain}:{pair_id}'
+
+  def _audio_path(self, record: dict[str, Any], domain: str) -> str:
+    path_key = f'{domain}_audio_path'
+    repo_key = f'{domain}_repo_id'
+    revision_key = f'{domain}_revision'
+    relative_path = str(record[path_key])
+
+    if self.base_path is not None:
+      local_path = os.path.join(self.base_path, relative_path)
+      if epath.Path(local_path).exists():
+        return local_path
+
+    return hf_hub_download(
+        repo_id=str(record[repo_key]),
+        filename=relative_path,
+        revision=str(record[revision_key]),
+        repo_type='dataset',
+    )
+
+  def _get_domain_sound(
+      self, record: dict[str, Any], domain: str
+  ) -> types.Sound:
+    waveform, sample_rate = utils.read_audio(self._audio_path(record, domain))
+    context = types.SoundContextParams(
+        id=self.sound_id(record['pair_id'], domain),
+        sample_rate=sample_rate,
+        length=len(waveform),
+        waveform_end_second=(
+            len(waveform) / sample_rate if sample_rate > 0 else 0.0
+        ),
+    )
+    return types.Sound(waveform=waveform, context=context)
+
+  def get_real_sound(self, record: dict[str, Any]) -> types.Sound:
+    return self._get_domain_sound(record, 'real')
+
+  def get_synthetic_sound(self, record: dict[str, Any]) -> types.Sound:
+    return self._get_domain_sound(record, 'synthetic')
+
+  def get_sound(self, record: dict[str, Any]) -> types.Sound:
+    if 'domain' not in record:
+      raise ValueError(
+          'Doppelganger records passed to get_sound() must include a domain.'
+      )
+    return self._get_domain_sound(record, str(record['domain']))

--- a/mseb/datasets/doppelganger_test.py
+++ b/mseb/datasets/doppelganger_test.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The MSEB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Doppelganger dataset loader."""
+
+import os
+
+from absl.testing import absltest
+from mseb import types
+from mseb.datasets import doppelganger
+import numpy as np
+import pandas as pd
+from scipy.io import wavfile
+
+
+def create_mock_dataset(base_dir: str) -> None:
+  metadata_dir = os.path.join(base_dir, 'mseb')
+  os.makedirs(metadata_dir)
+  audio_dir = os.path.join(base_dir, 'audio')
+  os.makedirs(audio_dir)
+
+  records = []
+  for pair_id, event_id in (('1', 'A'), ('2', 'A'), ('3', 'B')):
+    real_path = f'audio/real_{pair_id}.wav'
+    synthetic_path = f'audio/synthetic_{pair_id}.wav'
+    wavfile.write(
+        os.path.join(base_dir, real_path),
+        16000,
+        np.zeros(8000, dtype=np.float32),
+    )
+    wavfile.write(
+        os.path.join(base_dir, synthetic_path),
+        16000,
+        np.ones(4000, dtype=np.float32),
+    )
+    records.append({
+        'pair_id': pair_id,
+        'event_id': event_id,
+        'event_name': event_id,
+        'morphology': 'test',
+        'source_clip_id': pair_id,
+        'real_repo_id': 'unused',
+        'real_revision': 'unused',
+        'real_audio_path': real_path,
+        'synthetic_repo_id': 'unused',
+        'synthetic_revision': 'unused',
+        'synthetic_audio_path': synthetic_path,
+    })
+  pd.DataFrame(records).to_csv(
+      os.path.join(metadata_dir, 'test.csv'), index=False
+  )
+
+
+class DoppelgangerDatasetTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.base_dir = self.create_tempdir().full_path
+    create_mock_dataset(self.base_dir)
+    self.dataset = doppelganger.DoppelgangerDataset(
+        split='test', base_path=self.base_dir
+    )
+
+  def test_metadata_loading(self):
+    self.assertLen(self.dataset, 3)
+    self.assertEqual(
+        self.dataset.get_task_data()['pair_id'].tolist(),
+        [
+            '1',
+            '2',
+            '3',
+        ],
+    )
+
+  def test_domain_sounds(self):
+    record = self.dataset.get_task_data().iloc[0].to_dict()
+    real = self.dataset.get_real_sound(record)
+    synthetic = self.dataset.get_synthetic_sound(record)
+
+    self.assertIsInstance(real, types.Sound)
+    self.assertEqual(real.context.id, 'real:1')
+    self.assertLen(real.waveform, 8000)
+    self.assertEqual(synthetic.context.id, 'synthetic:1')
+    self.assertLen(synthetic.waveform, 4000)
+
+  def test_get_sound_requires_domain(self):
+    record = self.dataset.get_task_data().iloc[0].to_dict()
+    with self.assertRaisesRegex(ValueError, 'must include a domain'):
+      self.dataset.get_sound(record)
+
+  def test_split_validation(self):
+    with self.assertRaisesRegex(ValueError, 'Split must be test'):
+      doppelganger.DoppelgangerDataset(split='train', base_path=self.base_dir)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/mseb/evaluators/retrieval_evaluator.py
+++ b/mseb/evaluators/retrieval_evaluator.py
@@ -136,6 +136,17 @@ def em(value: float = 0.0, std: float | None = None):
   )
 
 
+def map(value: float = 0.0, std: float | None = None):  # pylint: disable=redefined-builtin
+  return types.Score(
+      metric='MAP',
+      description='Mean Average Precision',
+      value=value,
+      min=0,
+      max=1,
+      std=std,
+  )
+
+
 def compute_recall_at_k(
     reference: str | Sequence[str],
     predicted_neighbors: Sequence[str],
@@ -178,6 +189,7 @@ def _compute_metrics(
   values_by_metric = {
       'mrr': [],
       'em': [],
+      'map': [],
       'recall_at_k': [],
       'recall_at_inf': [],
       'invalid': [],
@@ -206,6 +218,13 @@ def _compute_metrics(
               )
           )
       )
+      values_by_metric['map'].append(
+          types.WeightedValue(
+              value=metrics_lib.compute_average_precision(
+                  reference_id.reference_id, ranked_doc_ids
+              )
+          )
+      )
       values_by_metric['recall_at_k'].append(
           types.WeightedValue(
               value=compute_recall_at_k(
@@ -225,7 +244,7 @@ def _compute_metrics(
       values_by_metric['ndcg'].append(
           types.WeightedValue(
               value=metrics_lib.compute_ndcg_at_k(
-                  reference_id.reference_id, ranked_doc_ids, k=10  # pyrefly: ignore[bad-argument-type]
+                  reference_id.reference_id, ranked_doc_ids, k=10
               )
           )
       )
@@ -234,6 +253,7 @@ def _compute_metrics(
     else:
       values_by_metric['mrr'].append(types.WeightedValue(value=0.0))
       values_by_metric['em'].append(types.WeightedValue(value=0.0))
+      values_by_metric['map'].append(types.WeightedValue(value=0.0))
       values_by_metric['recall_at_k'].append(types.WeightedValue(value=0.0))
       values_by_metric['recall_at_inf'].append(types.WeightedValue(value=0.0))
       values_by_metric['ndcg'].append(types.WeightedValue(value=0.0))
@@ -257,6 +277,9 @@ def _compute_metrics(
   )
   em_score = em(
       *evaluator_lib.compute_weighted_average_and_std(values_by_metric['em'])
+  )
+  map_score = map(
+      *evaluator_lib.compute_weighted_average_and_std(values_by_metric['map'])
   )
   recall_at_k = evaluator_lib.compute_weighted_average_and_std(
       values_by_metric['recall_at_k']
@@ -318,6 +341,7 @@ def _compute_metrics(
   return [
       mrr_score,
       em_score,
+      map_score,
       recall_at_k_score,
       recall_at_inf_score,
       invalid_result_score,
@@ -351,7 +375,9 @@ class RetrievalEvaluator:
     predictions = {}
     for sound_id, embeddings in embeddings_by_sound_id.items():
       assert hasattr(embeddings, 'embedding')
-      embedding: jaxtyping.Float[jaxtyping.Array, 'N D'] = embeddings.embedding  # pyrefly: ignore[bad-assignment]
+      embedding: jaxtyping.Float[jaxtyping.Array, 'N D'] = (
+          embeddings.embedding
+      )  # pyrefly: ignore[bad-assignment]
       ranked_index_ids, ranked_doc_scores = self.searcher.search_batched(
           embedding.astype(np.float32)
       )
@@ -463,7 +489,9 @@ def build_index(
 
   def _get_embedding(emb: types.MultiModalEmbedding) -> np.ndarray:
     assert hasattr(emb, 'embedding')
-    embedding: jaxtyping.Float[jaxtyping.Array, '1 D'] = emb.embedding  # pyrefly: ignore[bad-assignment]
+    embedding: jaxtyping.Float[jaxtyping.Array, '1 D'] = (
+        emb.embedding
+    )  # pyrefly: ignore[bad-assignment]
     return embedding[0]  # pyrefly: ignore[bad-return]
 
   id_by_index_id: Sequence[str] = sorted(embeddings.keys())
@@ -471,6 +499,7 @@ def build_index(
       [_get_embedding(embeddings[did]) for did in id_by_index_id], np.float32
   )
   n = len(id_by_index_id)
+  k = min(k, n)
   if not allow_scann or n < 50_000:
     logger.info('Building brute force index with %d documents...', n)
     searcher = BruteForceSearcher(candidates, num_neighbors=k)

--- a/mseb/evaluators/retrieval_evaluator_test.py
+++ b/mseb/evaluators/retrieval_evaluator_test.py
@@ -101,14 +101,18 @@ class RetrievalEvaluatorTest(absltest.TestCase):
     predictions = evaluator.compute_predictions(
         embeddings_by_sound_id={
             '1': types.SoundEmbedding(
-                timestamps=np.array([[0.0, 1.0]]),  # pyrefly: ignore[bad-argument-type]
+                timestamps=np.array(
+                    [[0.0, 1.0]]
+                ),  # pyrefly: ignore[bad-argument-type]
                 embedding=np.array([[1.0, 2.0, 3.0]]),
                 context=types.SoundContextParams(
                     id='1', sample_rate=16000, length=16000 * 5
                 ),
             ),
             '2': types.SoundEmbedding(
-                timestamps=np.array([[0.0, 1.0]]),  # pyrefly: ignore[bad-argument-type]
+                timestamps=np.array(
+                    [[0.0, 1.0]]
+                ),  # pyrefly: ignore[bad-argument-type]
                 embedding=np.array([[1.0, 2.0, 3.0]]),
                 context=types.SoundContextParams(
                     id='2', sample_rate=16000, length=16000 * 5
@@ -158,7 +162,7 @@ class RetrievalEvaluatorTest(absltest.TestCase):
             ),
         ],
     )
-    self.assertLen(scores, 7)
+    self.assertLen(scores, 8)
     for score in scores:
       if score.metric == 'MRR':
         npt.assert_equal(score.value, (0.5 + 1.0) / 2)
@@ -166,6 +170,9 @@ class RetrievalEvaluatorTest(absltest.TestCase):
       elif score.metric == 'EM':
         npt.assert_equal(score.value, (0.0 + 1.0) / 2)
         npt.assert_equal(score.std, 1 / 2)
+      elif score.metric == 'MAP':
+        npt.assert_equal(score.value, (0.5 + 1.0) / 2)
+        npt.assert_equal(score.std, 1 / 4)
       elif score.metric == 'RecallAt10':
         npt.assert_equal(score.value, (1.0 + 1.0) / 2)
         npt.assert_equal(score.std, 0.0)
@@ -246,7 +253,7 @@ class RetrievalEvaluatorPartitionedTest(absltest.TestCase):
             ),
         ],
     )
-    self.assertLen(scores, 7)
+    self.assertLen(scores, 8)
     for score in scores:
       if score.metric == 'MRR':
         npt.assert_equal(score.value, (0.5 + 1.0) / 2)
@@ -254,6 +261,9 @@ class RetrievalEvaluatorPartitionedTest(absltest.TestCase):
       elif score.metric == 'EM':
         npt.assert_equal(score.value, (0.0 + 1.0) / 2)
         npt.assert_equal(score.std, 1 / 2)
+      elif score.metric == 'MAP':
+        npt.assert_equal(score.value, (0.5 + 1.0) / 2)
+        npt.assert_equal(score.std, 1 / 4)
       elif score.metric == 'RecallAt10':
         npt.assert_equal(score.value, (1.0 + 1.0) / 2)
         npt.assert_equal(score.std, 0.0)
@@ -279,14 +289,18 @@ class RetrievalEvaluatorPartitionedTest(absltest.TestCase):
     predictions = evaluator.compute_predictions(
         embeddings_by_sound_id={
             '1': types.SoundEmbedding(
-                timestamps=np.array([[0.0, 1.0]]),  # pyrefly: ignore[bad-argument-type]
+                timestamps=np.array(
+                    [[0.0, 1.0]]
+                ),  # pyrefly: ignore[bad-argument-type]
                 embedding=np.array([[1.0, 2.0, 3.0]]),
                 context=types.SoundContextParams(
                     id='1', sample_rate=16000, length=16000 * 5
                 ),
             ),
             '2': types.SoundEmbedding(
-                timestamps=np.array([[0.0, 1.0]]),  # pyrefly: ignore[bad-argument-type]
+                timestamps=np.array(
+                    [[0.0, 1.0]]
+                ),  # pyrefly: ignore[bad-argument-type]
                 embedding=np.array([[1.0, 2.0, 3.0]]),
                 context=types.SoundContextParams(
                     id='2', sample_rate=16000, length=16000 * 5
@@ -365,7 +379,7 @@ class RetrievalEvaluatorUtilTest(absltest.TestCase):
             ),
         ],
     )
-    self.assertLen(scores, 7)
+    self.assertLen(scores, 8)
     for score in scores:
       if score.metric == 'MRR':
         npt.assert_equal(score.value, (0.5 + 1.0) / 2)
@@ -373,6 +387,9 @@ class RetrievalEvaluatorUtilTest(absltest.TestCase):
       elif score.metric == 'EM':
         npt.assert_equal(score.value, (0.0 + 1.0) / 2)
         npt.assert_equal(score.std, 1 / 2)
+      elif score.metric == 'MAP':
+        npt.assert_equal(score.value, (0.5 + 1.0) / 2)
+        npt.assert_equal(score.std, 1 / 4)
       elif score.metric == 'RecallAt10':
         npt.assert_equal(score.value, (1.0 + 1.0) / 2)
         npt.assert_equal(score.std, 0.0)
@@ -461,14 +478,17 @@ class BruteForceSearcherTest(absltest.TestCase):
 
   def _make_candidates(self):
     """Returns a 6x3 candidate matrix with known dot-product ordering."""
-    return np.array([
-        [1.0, 0.0, 0.0],  # idx 0
-        [0.0, 1.0, 0.0],  # idx 1
-        [0.0, 0.0, 1.0],  # idx 2
-        [1.0, 1.0, 0.0],  # idx 3  (dot with [1,1,1] = 2)
-        [1.0, 1.0, 1.0],  # idx 4  (dot with [1,1,1] = 3)
-        [2.0, 0.0, 0.0],  # idx 5  (dot with [1,1,1] = 2)
-    ], dtype=np.float32)
+    return np.array(
+        [
+            [1.0, 0.0, 0.0],  # idx 0
+            [0.0, 1.0, 0.0],  # idx 1
+            [0.0, 0.0, 1.0],  # idx 2
+            [1.0, 1.0, 0.0],  # idx 3  (dot with [1,1,1] = 2)
+            [1.0, 1.0, 1.0],  # idx 4  (dot with [1,1,1] = 3)
+            [2.0, 0.0, 0.0],  # idx 5  (dot with [1,1,1] = 2)
+        ],
+        dtype=np.float32,
+    )
 
   def test_search_batched_top_k_ranking(self):
     """Top-k results are sorted descending by dot product."""
@@ -510,10 +530,13 @@ class BruteForceSearcherTest(absltest.TestCase):
     """Each query in a batch gets independently correct results."""
     candidates = self._make_candidates()
     searcher = BruteForceSearcher(candidates, num_neighbors=1)
-    queries = np.array([
-        [1.0, 0.0, 0.0],  # best match: idx 5 (dot=2)
-        [0.0, 0.0, 1.0],  # best match: idx 2 (dot=1) or idx 4 (dot=1)
-    ], dtype=np.float32)
+    queries = np.array(
+        [
+            [1.0, 0.0, 0.0],  # best match: idx 5 (dot=2)
+            [0.0, 0.0, 1.0],  # best match: idx 2 (dot=1) or idx 4 (dot=1)
+        ],
+        dtype=np.float32,
+    )
     ids, scores = searcher.search_batched(queries)
     self.assertEqual(ids.shape, (2, 1))
     npt.assert_array_equal(ids[0], [5])
@@ -532,11 +555,14 @@ class BruteForceSearcherTest(absltest.TestCase):
 
   def test_scores_match_manual_dot_product(self):
     """Returned scores exactly equal the dot products."""
-    candidates = np.array([
-        [1.0, 2.0],
-        [3.0, 4.0],
-        [5.0, 6.0],
-    ], dtype=np.float32)
+    candidates = np.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+        ],
+        dtype=np.float32,
+    )
     searcher = BruteForceSearcher(candidates, num_neighbors=3)
     query = np.array([[1.0, 1.0]], dtype=np.float32)
     ids, scores = searcher.search_batched(query)

--- a/mseb/metrics.py
+++ b/mseb/metrics.py
@@ -108,35 +108,78 @@ def compute_exact_match(
   return 0.0
 
 
-def compute_ndcg_at_k(
-    reference: str, predicted_neighbors: Sequence[str], k: int = 10
+def compute_average_precision(
+    reference: str | Sequence[str], predicted_neighbors: Sequence[str]
 ) -> float:
-  """Computes NDCG@k with binary relevance (single relevant document).
+  """Computes average precision for binary relevance.
 
-  This matches the pytrec_eval ndcg_cut metric for single-relevant-doc queries:
-  DCG@k  = 1/log2(rank+1)  if the relevant doc appears at position `rank` <= k.
-  IDCG@k = 1/log2(2)  = 1  (ideal: relevant doc at rank 1).
-  NDCG@k = DCG@k / IDCG@k  = 1/log2(rank+1).
+  The denominator is the total number of relevant documents, so callers must
+  provide a ranking deep enough to retrieve every relevant document when they
+  want full-ranking average precision.
 
   Args:
-    reference: The ground-truth document ID.
+    reference: One or more ground-truth document IDs.
+    predicted_neighbors: Ranked list of predicted document IDs.
+
+  Returns:
+    Average precision in [0, 1].
+  """
+  if isinstance(reference, str):
+    reference = [reference]
+  relevant = set(reference)
+  if not relevant:
+    return 0.0
+
+  num_retrieved_relevant = 0
+  precision_sum = 0.0
+  seen_relevant = set()
+  for rank, neighbor in enumerate(predicted_neighbors, start=1):
+    if neighbor in relevant and neighbor not in seen_relevant:
+      seen_relevant.add(neighbor)
+      num_retrieved_relevant += 1
+      precision_sum += num_retrieved_relevant / rank
+  return precision_sum / len(relevant)
+
+
+def compute_ndcg_at_k(
+    reference: str | Sequence[str],
+    predicted_neighbors: Sequence[str],
+    k: int = 10,
+) -> float:
+  """Computes NDCG@k with binary relevance.
+
+  Args:
+    reference: One or more ground-truth document IDs.
     predicted_neighbors: Ranked list of predicted document IDs.
     k: Cutoff for the ranked list.
 
   Returns:
     NDCG@k score in [0, 1].
   """
+  if isinstance(reference, str):
+    reference = [reference]
+  relevant = set(reference)
+  if not relevant or k <= 0:
+    return 0.0
+
+  dcg = 0.0
+  seen_relevant = set()
   for rank, neighbor in enumerate(predicted_neighbors[:k], start=1):
-    if reference == neighbor:
-      return 1.0 / np.log2(rank + 1)
-  return 0.0
+    if neighbor in relevant and neighbor not in seen_relevant:
+      seen_relevant.add(neighbor)
+      dcg += 1.0 / np.log2(rank + 1)
+  ideal_length = min(len(relevant), k)
+  idcg = sum(1.0 / np.log2(rank + 1) for rank in range(1, ideal_length + 1))
+  return dcg / idcg
 
 
 def _compute_levenshtein_stats(
     truth: str, hypothesis: str
 ) -> Mapping[str, int]:
   """Wrapper around jiwer library to compute Levenshtein statistics."""
-  stats = jiwer.process_words(reference=[truth], hypothesis=[hypothesis])  # pytype: disable=module-attr
+  stats = jiwer.process_words(
+      reference=[truth], hypothesis=[hypothesis]
+  )  # pytype: disable=module-attr
   return {
       'substitutions': stats.substitutions,
       'deletions': stats.deletions,

--- a/mseb/metrics_test.py
+++ b/mseb/metrics_test.py
@@ -130,6 +130,46 @@ class MetricsTest(parameterized.TestCase):
     )
     self.assertEqual(exact_match, expected_exact_match)
 
+  @parameterized.named_parameters(
+      dict(
+          testcase_name='single_reference',
+          reference='b',
+          predicted_neighbors=['a', 'b', 'c'],
+          expected_average_precision=0.5,
+      ),
+      dict(
+          testcase_name='multiple_references',
+          reference=['b', 'd'],
+          predicted_neighbors=['a', 'b', 'c', 'd'],
+          expected_average_precision=(1 / 2 + 2 / 4) / 2,
+      ),
+      dict(
+          testcase_name='missing_relevant_document',
+          reference=['b', 'd'],
+          predicted_neighbors=['b', 'a', 'c'],
+          expected_average_precision=0.5,
+      ),
+      dict(
+          testcase_name='empty_reference',
+          reference=[],
+          predicted_neighbors=['a'],
+          expected_average_precision=0.0,
+      ),
+      dict(
+          testcase_name='duplicate_prediction',
+          reference=['a', 'b'],
+          predicted_neighbors=['a', 'a', 'b'],
+          expected_average_precision=(1 + 2 / 3) / 2,
+      ),
+  )
+  def test_compute_average_precision(
+      self, reference, predicted_neighbors, expected_average_precision
+  ):
+    average_precision = metrics.compute_average_precision(
+        reference=reference, predicted_neighbors=predicted_neighbors
+    )
+    self.assertEqual(average_precision, expected_average_precision)
+
   def test_compute_word_errors_correct(self):
     word_errors, word_errors_weight = metrics.compute_word_errors(
         truth='This is a test.',
@@ -291,9 +331,7 @@ class MetricsTest(parameterized.TestCase):
     z2 = np.array([[-50.0, 0.0]])
     # Scaled to [1,0] and [-1,0] -> Euclidean dist is 2.0
     res = metrics.compute_continuous_edit_distance(
-        z1,
-        z2,
-        unit_sphere_scaling=True
+        z1, z2, unit_sphere_scaling=True
     )
     self.assertAlmostEqual(res['raw_distance'], 2.0)
     self.assertEqual(res['reference_length'], 1.0)
@@ -364,6 +402,21 @@ class MetricsTest(parameterized.TestCase):
           predicted_neighbors=['a', 'b', 'c'],
           k=2,
           expected_ndcg=1.0 / np.log2(3),  # rank 2, within k=2
+      ),
+      dict(
+          testcase_name='multiple_references',
+          reference=['b', 'd'],
+          predicted_neighbors=['a', 'b', 'c', 'd'],
+          k=4,
+          expected_ndcg=(1 / np.log2(3) + 1 / np.log2(5))
+          / (1 + 1 / np.log2(3)),
+      ),
+      dict(
+          testcase_name='duplicate_prediction',
+          reference=['a', 'b'],
+          predicted_neighbors=['a', 'a', 'b'],
+          k=3,
+          expected_ndcg=(1 + 1 / np.log2(4)) / (1 + 1 / np.log2(3)),
       ),
   )
   def test_compute_ndcg_at_k(

--- a/mseb/tasks/__init__.py
+++ b/mseb/tasks/__init__.py
@@ -133,3 +133,8 @@ try:
   from .retrievals.image_to_speech.spoken_coco import *
 except ImportError:
   pass
+
+try:
+  from .retrievals.audio_to_audio.doppelganger import *
+except ImportError:
+  pass

--- a/mseb/tasks/docs/dataset_doppelganger.md
+++ b/mseb/tasks/docs/dataset_doppelganger.md
@@ -1,0 +1,20 @@
+# Doppelganger
+
+Doppelganger is a benchmark for matching real sound effects to
+audio-conditioned synthetic twins. The MSEB configuration contains 3,065
+one-to-one pairs from the held-out test split, covering 34 sound events in the
+Universal Category System taxonomy.
+
+The real recordings come from FSD50K. The synthetic clips were generated from
+those recordings with Stable Audio Open. MSEB reads the dedicated `mseb`
+configuration from
+[`elliottash/doppelganger`](https://huggingface.co/datasets/elliottash/doppelganger).
+The configuration pins the audio revisions and records each real clip's
+Freesound title, uploader, source URL, and license URL.
+
+Licensing is clip-specific. Real audio includes CC0, CC BY 3.0, CC BY-NC 3.0,
+and Sampling+ 1.0 clips. Synthetic audio is covered by the Stability AI
+Community License. The metadata and generation records are MIT licensed.
+
+Reference: [Doppelganger: Sound Effects and Their Synthetic
+Twins](https://arxiv.org/abs/2607.04337).

--- a/mseb/tasks/docs/doppelganger_retrieval.md
+++ b/mseb/tasks/docs/doppelganger_retrieval.md
@@ -1,0 +1,27 @@
+# Doppelganger retrieval
+
+Doppelganger measures whether an audio embedding preserves identity and event
+category across the real-synthetic boundary. The benchmark evaluates the fixed
+3,065-pair test set in both directions:
+
+- `DoppelgangerSyntheticToRealRetrieval` uses each synthetic twin as a query
+  and the 3,065 real recordings as the gallery.
+- `DoppelgangerRealToSyntheticRetrieval` uses each real recording as a query
+  and the 3,065 synthetic twins as the gallery.
+
+Each direction reports two subtasks. In `exact_source`, only the query's paired
+counterpart is relevant. In `category`, every gallery item with the same UCS
+event category as the query is relevant. The category subtask therefore asks a
+different question from exact matching: it rewards an embedding for retrieving
+the right kind of sound even when it does not recover the particular source
+recording.
+
+MSEB ranks the full gallery by its standard dot-product similarity. Full
+rankings are retained so mean average precision (MAP) is exact for the
+multi-relevant category task. MAP is the main score. For exact-source
+retrieval, MAP equals reciprocal rank; `EM` gives top-1 exact-source recall.
+For category retrieval, MAP averages precision at every same-category hit;
+`EM` indicates whether the top-ranked result is in the correct category.
+
+The split and pair identities are fixed by the versioned `mseb` Hugging Face
+configuration. No training data is part of this task.

--- a/mseb/tasks/retrieval.py
+++ b/mseb/tasks/retrieval.py
@@ -65,14 +65,17 @@ class RetrievalTask(task.MSEBTask):
   def __init__(
       self,
       id_by_index_id_filepath: str = 'ids.txt',
+      top_k: int = 10,
   ):
     """Initializes the retrieval task.
 
     Args:
       id_by_index_id_filepath: The filepath to save the id by index id mapping.
+      top_k: The number of retrieved documents retained for metric computation.
     """
     super().__init__()
     self.id_by_index_id_filepath = id_by_index_id_filepath
+    self.top_k = top_k
     self._evaluator = None
 
   @property
@@ -84,7 +87,9 @@ class RetrievalTask(task.MSEBTask):
   @property
   def index_dir(self) -> str:
     """The directory where the index is stored."""
-    return os.path.join(task.TASK_CACHE_BASEPATH.value, 'retrievals')  # pyrefly: ignore[no-matching-overload]
+    return os.path.join(
+        task.TASK_CACHE_BASEPATH.value, 'retrievals'
+    )  # pyrefly: ignore[no-matching-overload]
 
   def setup(
       self,
@@ -118,7 +123,7 @@ class RetrievalTask(task.MSEBTask):
               for doc in self.documents()
           }
         searcher, id_by_index_id = retrieval_evaluator.build_index(
-            embeddings, allow_scann=_ALLOW_SCANN.value
+            embeddings, k=self.top_k, allow_scann=_ALLOW_SCANN.value
         )
         retrieval_evaluator.save_index(
             searcher, id_by_index_id, index_dir, self.id_by_index_id_filepath
@@ -131,7 +136,9 @@ class RetrievalTask(task.MSEBTask):
         searcher, id_by_index_id = None, None
 
     self._evaluator = retrieval_evaluator.RetrievalEvaluator(
-        searcher=searcher, id_by_index_id=id_by_index_id  # pyrefly: ignore[bad-argument-type]
+        searcher=searcher,
+        id_by_index_id=id_by_index_id,  # pyrefly: ignore[bad-argument-type]
+        top_k=self.top_k,
     )
 
   def setup_partitioned(
@@ -166,7 +173,7 @@ class RetrievalTask(task.MSEBTask):
               for doc in self.documents()
           }
         searcher, id_by_index_id = retrieval_evaluator.build_index(
-            embeddings, allow_scann=_ALLOW_SCANN.value
+            embeddings, k=self.top_k, allow_scann=_ALLOW_SCANN.value
         )
         retrieval_evaluator.save_index(
             searcher,
@@ -182,7 +189,7 @@ class RetrievalTask(task.MSEBTask):
         ) from FileNotFoundError
 
     self._evaluator = retrieval_evaluator.RetrievalEvaluatorPartitioned(
-        index_dir=index_dir
+        index_dir=index_dir, top_k=self.top_k
     )
 
   def compute_scores(
@@ -205,7 +212,9 @@ class RetrievalTask(task.MSEBTask):
         ):
           items = []
           for n, item in enumerate(prediction.items, 1):
-            item['score'] = item.get('score', 1 / n)  # pyrefly: ignore[unsupported-operation]
+            item['score'] = item.get(
+                'score', 1 / n
+            )  # pyrefly: ignore[unsupported-operation]
             items.append(item)
           prediction = types.ValidListPrediction(items)
         predictions[sound_id] = prediction

--- a/mseb/tasks/retrievals/audio_to_audio/__init__.py
+++ b/mseb/tasks/retrievals/audio_to_audio/__init__.py
@@ -1,0 +1,1 @@
+"""Audio-to-audio retrieval tasks."""

--- a/mseb/tasks/retrievals/audio_to_audio/doppelganger.py
+++ b/mseb/tasks/retrievals/audio_to_audio/doppelganger.py
@@ -1,0 +1,173 @@
+# Copyright 2026 The MSEB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Doppelganger cross-domain audio retrieval tasks."""
+
+import os
+from typing import Iterable
+
+from mseb import types
+from mseb.datasets import doppelganger
+from mseb.evaluators import retrieval_evaluator
+from mseb.tasks import retrieval
+
+
+_GALLERY_SIZE = 3065
+_SUB_TASKS = ['exact_source', 'category']
+
+
+class _DoppelgangerRetrieval(retrieval.RetrievalTask):
+  """Shared implementation for both synthetic-real retrieval directions."""
+
+  query_domain: str
+  document_domain: str
+
+  def __init__(self):
+    # Full-gallery rankings are required for category-level average precision.
+    super().__init__(top_k=_GALLERY_SIZE)
+    self._dataset = None
+
+  def _get_dataset(self) -> doppelganger.DoppelgangerDataset:
+    if self._dataset is None:
+      self._dataset = doppelganger.DoppelgangerDataset(split='test')
+    return self._dataset
+
+  @property
+  def index_dir(self) -> str:
+    direction = f'{self.query_domain}_to_{self.document_domain}'
+    return os.path.join(super().index_dir, f'doppelganger_{direction}')
+
+  @property
+  def sub_tasks(self) -> list[str]:
+    return _SUB_TASKS
+
+  def get_documents_source(
+      self,
+  ) -> tuple[doppelganger.DoppelgangerDataset, str]:
+    return self._get_dataset(), self.document_domain
+
+  @staticmethod
+  def documents_generator(
+      documents_source: tuple[doppelganger.DoppelgangerDataset, str],
+  ) -> Iterable[types.Sound]:
+    dataset, domain = documents_source
+    for record in dataset.get_task_data().to_dict('records'):
+      if domain == 'real':
+        yield dataset.get_real_sound(record)
+      else:
+        yield dataset.get_synthetic_sound(record)
+
+  def multimodal_inputs(self) -> Iterable[types.Sound]:
+    dataset = self._get_dataset()
+    for record in dataset.get_task_data().to_dict('records'):
+      if self.query_domain == 'real':
+        yield dataset.get_real_sound(record)
+      else:
+        yield dataset.get_synthetic_sound(record)
+
+  def examples(
+      self, sub_task: str
+  ) -> Iterable[retrieval_evaluator.RetrievalReferenceId]:
+    if sub_task not in _SUB_TASKS:
+      raise ValueError(f'Unknown Doppelganger sub-task: {sub_task}.')
+
+    dataset = self._get_dataset()
+    records = dataset.get_task_data().to_dict('records')
+    document_ids_by_event: dict[str, list[str]] = {}
+    if sub_task == 'category':
+      for record in records:
+        document_ids_by_event.setdefault(record['event_id'], []).append(
+            dataset.sound_id(record['pair_id'], self.document_domain)
+        )
+
+    for record in records:
+      if sub_task == 'exact_source':
+        reference_id: str | list[str] = dataset.sound_id(
+            record['pair_id'], self.document_domain
+        )
+      else:
+        reference_id = document_ids_by_event[record['event_id']]
+      yield retrieval_evaluator.RetrievalReferenceId(
+          sound_id=dataset.sound_id(record['pair_id'], self.query_domain),
+          reference_id=reference_id,
+      )
+
+
+_DATASET_METADATA = types.Dataset(
+    name='Doppelganger',
+    path='https://huggingface.co/datasets/elliottash/doppelganger',
+    revision='mseb-v1',
+)
+
+_SCORES = [
+    retrieval_evaluator.map(),
+    retrieval_evaluator.mrr(),
+    retrieval_evaluator.em(),
+]
+
+
+class DoppelgangerSyntheticToRealRetrieval(_DoppelgangerRetrieval):
+  """Retrieves real sources using their synthetic twins as queries."""
+
+  query_domain = 'synthetic'
+  document_domain = 'real'
+
+  metadata = types.TaskMetadata(
+      name='DoppelgangerSyntheticToRealRetrieval',
+      description=(
+          'Retrieve real sound effects from audio-conditioned synthetic '
+          'queries, using exact-source and UCS-category relevance.'
+      ),
+      reference='https://arxiv.org/abs/2607.04337',
+      type='AudioRetrieval',
+      category='audio',
+      main_score='MAP',
+      revision='1.0.0',
+      dataset=_DATASET_METADATA,
+      scores=_SCORES,
+      eval_splits=['test'],
+      eval_langs=['und'],
+      domains=['audio'],
+      task_subtypes=['retrieval', 'cross-domain'],
+      documentation_file='doppelganger_retrieval.md',
+      dataset_documentation_file='dataset_doppelganger.md',
+  )
+
+
+class DoppelgangerRealToSyntheticRetrieval(_DoppelgangerRetrieval):
+  """Retrieves synthetic twins using their real sources as queries."""
+
+  query_domain = 'real'
+  document_domain = 'synthetic'
+
+  metadata = types.TaskMetadata(
+      name='DoppelgangerRealToSyntheticRetrieval',
+      description=(
+          'Retrieve audio-conditioned synthetic twins from real sound '
+          'queries, using exact-source and UCS-category relevance.'
+      ),
+      reference='https://arxiv.org/abs/2607.04337',
+      type='AudioRetrieval',
+      category='audio',
+      main_score='MAP',
+      revision='1.0.0',
+      dataset=_DATASET_METADATA,
+      scores=_SCORES,
+      eval_splits=['test'],
+      eval_langs=['und'],
+      domains=['audio'],
+      task_subtypes=['retrieval', 'cross-domain'],
+      documentation_file='doppelganger_retrieval.md',
+      dataset_documentation_file='dataset_doppelganger.md',
+  )

--- a/mseb/tasks/retrievals/audio_to_audio/doppelganger_test.py
+++ b/mseb/tasks/retrievals/audio_to_audio/doppelganger_test.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The MSEB Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Doppelganger audio-to-audio retrieval tasks."""
+
+from absl.testing import absltest
+from mseb import types
+from mseb.datasets import doppelganger as doppelganger_dataset
+from mseb.datasets.doppelganger_test import create_mock_dataset
+from mseb.tasks.retrievals.audio_to_audio import doppelganger
+
+
+class DoppelgangerRetrievalTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    base_dir = self.create_tempdir().full_path
+    create_mock_dataset(base_dir)
+    self.dataset = doppelganger_dataset.DoppelgangerDataset(
+        split='test', base_path=base_dir
+    )
+
+  def _task(self, task_class):
+    task = task_class()
+    task._dataset = self.dataset  # pylint: disable=protected-access
+    return task
+
+  def test_tasks_are_registered_with_expected_metadata(self):
+    synthetic_to_real = self._task(
+        doppelganger.DoppelgangerSyntheticToRealRetrieval
+    )
+    real_to_synthetic = self._task(
+        doppelganger.DoppelgangerRealToSyntheticRetrieval
+    )
+    self.assertEqual(synthetic_to_real.metadata.main_score, 'MAP')
+    self.assertEqual(real_to_synthetic.metadata.main_score, 'MAP')
+    self.assertEqual(
+        synthetic_to_real.sub_tasks,
+        [
+            'exact_source',
+            'category',
+        ],
+    )
+
+  def test_synthetic_to_real_inputs_and_documents(self):
+    task = self._task(doppelganger.DoppelgangerSyntheticToRealRetrieval)
+    inputs = list(task.multimodal_inputs())
+    documents = list(task.documents())
+    self.assertTrue(all(isinstance(sound, types.Sound) for sound in inputs))
+    self.assertEqual(
+        {sound.context.id for sound in inputs},
+        {'synthetic:1', 'synthetic:2', 'synthetic:3'},
+    )
+    self.assertEqual(
+        {sound.context.id for sound in documents},
+        {'real:1', 'real:2', 'real:3'},
+    )
+
+  def test_real_to_synthetic_inputs_and_documents(self):
+    task = self._task(doppelganger.DoppelgangerRealToSyntheticRetrieval)
+    self.assertEqual(
+        {sound.context.id for sound in task.multimodal_inputs()},
+        {'real:1', 'real:2', 'real:3'},
+    )
+    self.assertEqual(
+        {sound.context.id for sound in task.documents()},
+        {'synthetic:1', 'synthetic:2', 'synthetic:3'},
+    )
+
+  def test_exact_source_relevance(self):
+    task = self._task(doppelganger.DoppelgangerSyntheticToRealRetrieval)
+    references = {
+        example.sound_id: example.reference_id
+        for example in task.examples('exact_source')
+    }
+    self.assertEqual(references['synthetic:1'], 'real:1')
+    self.assertEqual(references['synthetic:3'], 'real:3')
+
+  def test_category_relevance(self):
+    task = self._task(doppelganger.DoppelgangerRealToSyntheticRetrieval)
+    references = {
+        example.sound_id: set(example.reference_id)
+        for example in task.examples('category')
+    }
+    self.assertEqual(references['real:1'], {'synthetic:1', 'synthetic:2'})
+    self.assertEqual(references['real:2'], {'synthetic:1', 'synthetic:2'})
+    self.assertEqual(references['real:3'], {'synthetic:3'})
+
+  def test_unknown_sub_task(self):
+    task = self._task(doppelganger.DoppelgangerSyntheticToRealRetrieval)
+    with self.assertRaisesRegex(ValueError, 'Unknown Doppelganger sub-task'):
+      list(task.examples('unknown'))
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

Adds [Doppelganger](https://arxiv.org/abs/2607.04337) as a cross-domain audio
retrieval benchmark in both directions:

- synthetic query to real gallery
- real query to synthetic gallery

Each direction exposes two subtasks:

- `exact_source`: only the paired real/synthetic counterpart is relevant
- `category`: every gallery clip in the query's UCS event category is relevant

## Dataset

The tasks use the dedicated, versioned [`mseb`
configuration](https://huggingface.co/datasets/elliottash/doppelganger/tree/mseb-v1/mseb)
on Hugging Face:

- 3,065 held-out pairs
- 34 UCS event categories
- immutable audio revisions
- per-clip Freesound title, uploader, source URL, and license URL

Real clips retain their original CC0, CC BY 3.0, CC BY-NC 3.0, or Sampling+
1.0 terms. Synthetic clips use the Stability AI Community License.

## Implementation

- adds a streaming/cached Doppelganger dataset loader
- registers `DoppelgangerSyntheticToRealRetrieval` and
  `DoppelgangerRealToSyntheticRetrieval`
- lets retrieval tasks configure `top_k`
- retains the full 3,065-item gallery so category MAP is exact
- adds multi-relevance average precision and multi-relevance NDCG
- documents the dataset, relevance definitions, and metric interpretation

## Validation

- `402 passed, 3 skipped, 131 deselected` for the full non-optional suite
- `79 passed, 2 deselected` for focused metrics/retrieval/Doppelganger tests
- live smoke test loaded all 3,065 pairs and decoded a pinned real/synthetic pair
- both new task names register with `MAP` as the main score

A pinned LAION CLAP baseline was scored on Modal using the published
embeddings:

| Direction | Exact EM | Exact MRR/MAP | Category EM | Category MAP |
|---|---:|---:|---:|---:|
| synthetic to real | 0.6121 | 0.6964 | 0.8046 | 0.3435 |
| real to synthetic | 0.5475 | 0.6416 | 0.8969 | 0.3691 |

The baseline uses MSEB's dot-product/full-gallery protocol; the published CLAP
embeddings are L2-normalized.
