### PR TITLE
Preserve batch dimensions in score ranking helpers

### DIFF
--- a/mseb/evaluator.py
+++ b/mseb/evaluator.py
@@ -164,27 +164,34 @@ def top_1(
     jaxtyping.Float[jaxtyping.Array, '*B 1'],
     jaxtyping.Int[jaxtyping.Array, '*B 1'],
 ]:
-  """Returns the top-1 value and its index of scores."""
-  top_id = np.argmax(scores)
-  return np.array([scores[top_id]]), np.array([top_id])  # pyrefly: ignore[bad-return]
+  """Returns the top-1 value and index along the last axis of scores."""
+  top_id = np.argmax(scores, axis=-1)[..., np.newaxis]
+  return np.take_along_axis(scores, top_id, axis=-1), top_id
 
 
 def top_k(scores: jaxtyping.Float[jaxtyping.Array, '*B N'], k: int) -> tuple[
     jaxtyping.Float[jaxtyping.Array, '*B k'],
     jaxtyping.Int[jaxtyping.Array, '*B k'],
 ]:
-  """Returns top k values and their indices of scores."""
-  k = min(k, len(scores))
-  ids_k = np.argpartition(scores, -k, axis=-1)[-k:]
-  ids = np.argsort(scores[ids_k], axis=-1)[::-1]
-  ids_k = ids_k[ids]
-  return scores[ids_k], ids_k  # pyrefly: ignore[bad-return]
+  """Returns top k values and indices along the last axis of scores."""
+  if k < 0:
+    raise ValueError(f'k must be non-negative, got {k}.')
+  k = min(k, scores.shape[-1])
+  if k == 0:
+    return scores[..., :0], np.empty(scores.shape[:-1] + (0,), dtype=np.intp)
+  ids_k = np.argpartition(scores, -k, axis=-1)[..., -k:]
+  values_k = np.take_along_axis(scores, ids_k, axis=-1)
+  order = np.argsort(values_k, axis=-1)[..., ::-1]
+  return (
+      np.take_along_axis(values_k, order, axis=-1),
+      np.take_along_axis(ids_k, order, axis=-1),
+  )
 
 
 def top_inf(scores: jaxtyping.Float[jaxtyping.Array, '*B N']) -> tuple[
     jaxtyping.Float[jaxtyping.Array, '*B N'],
     jaxtyping.Int[jaxtyping.Array, '*B N'],
 ]:
-  """Returns the values and their indices of scores in descending order."""
+  """Returns values and indices sorted descending along the last axis."""
   ids = np.argsort(-scores, axis=-1)
-  return scores[ids], ids  # pyrefly: ignore[bad-return]
+  return np.take_along_axis(scores, ids, axis=-1), ids

--- a/mseb/evaluator_test.py
+++ b/mseb/evaluator_test.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 from absl.testing import absltest
+from absl.testing import parameterized
 from mseb import evaluator
 from mseb import types
 import numpy as np
@@ -157,6 +158,52 @@ class EvaluatorTest(absltest.TestCase):
     top_k_scores, top_k_ids = evaluator.top_k(scores, k=10)
     npt.assert_almost_equal(top_k_scores, np.array([8, 5, 2, 0]))
     npt.assert_equal(top_k_ids, np.array([1, 2, 0, 3]))
+
+
+
+class BatchedRankingTest(parameterized.TestCase):
+
+  @parameterized.product(
+      batch_shape=[(), (2,), (2, 3), (0,)], k=[0, 1, 3, 7, 10]
+  )
+  def test_top_k_preserves_batch_axes(self, batch_shape, k):
+    scores = np.random.default_rng(7).normal(size=(*batch_shape, 7))
+    original = scores.copy()
+    values, indices = evaluator.top_k(scores, k=k)
+    expected = np.sort(scores, axis=-1)[..., ::-1][..., :k]
+    npt.assert_array_equal(values, expected)
+    self.assertEqual(indices.shape, (*batch_shape, min(k, 7)))
+    self.assertTrue(np.issubdtype(indices.dtype, np.integer))
+    npt.assert_array_equal(values, np.take_along_axis(scores, indices, axis=-1))
+    npt.assert_array_equal(scores, original)
+
+  @parameterized.product(
+      batch_shape=[(), (2,), (2, 3), (0,)], mode=['top_1', 'top_inf']
+  )
+  def test_rankers_preserve_batch_axes(self, batch_shape, mode):
+    scores = np.random.default_rng(17).normal(size=(*batch_shape, 7))
+    values, indices = getattr(evaluator, mode)(scores)
+    k = 1 if mode == 'top_1' else 7
+    expected = np.sort(scores, axis=-1)[..., ::-1][..., :k]
+    npt.assert_array_equal(values, expected)
+    self.assertEqual(indices.shape, expected.shape)
+    npt.assert_array_equal(values, np.take_along_axis(scores, indices, axis=-1))
+
+  @parameterized.parameters(0, 3)
+  def test_top_k_empty_candidate_axis(self, k):
+    values, indices = evaluator.top_k(np.empty((2, 0)), k=k)
+    self.assertEqual(values.shape, (2, 0))
+    self.assertEqual(indices.shape, (2, 0))
+
+  def test_top_k_negative_count(self):
+    with self.assertRaises(ValueError):
+      evaluator.top_k(np.array([1.0, 2.0]), k=-1)
+
+  def test_noncontiguous_scores(self):
+    scores = np.arange(24).reshape(4, 6).T[:, ::-1]
+    values, indices = evaluator.top_k(scores, k=2)
+    npt.assert_array_equal(values, np.sort(scores, axis=-1)[:, ::-1][:, :2])
+    npt.assert_array_equal(values, np.take_along_axis(scores, indices, axis=-1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The ranking helpers accept `*B N` scores but select or gather along the batch axis. Batched inputs can therefore raise indexing errors or mix examples. `top_k` also treats `k=0` as an unrestricted selection.

Rank and gather along the last axis, preserve leading dimensions, and handle zero/empty selections. Add coverage for multiple batch axes, empty batches, noncontiguous arrays and invalid negative counts.

Validation: all 42 evaluator tests and 13 classification-evaluator tests pass using their module runners. Twenty-six regression cases fail on unchanged upstream. All 600 single-example ranking comparisons, including ties, match upstream exactly. Syntax and `git diff --check` pass.
